### PR TITLE
feat: support ape >=0.8.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Ecosystem Plugin for Scroll support in Ape.
 
 ## Dependencies
 
-- [python3](https://www.python.org/downloads) version 3.8 or greater, python3-dev
+- [python3](https://www.python.org/downloads) version 3.9 or greater, python3-dev
 
 ## Installation
 

--- a/ape_scroll/__init__.py
+++ b/ape_scroll/__init__.py
@@ -1,7 +1,7 @@
 from ape import plugins
 from ape.api import NetworkAPI, create_network_type
 from ape.api.networks import LOCAL_NETWORK_NAME
-from ape_geth import GethProvider
+from ape_node import Node
 from ape_test import LocalProvider
 
 from .ecosystem import NETWORKS, Scroll, ScrollConfig
@@ -30,6 +30,6 @@ def networks():
 @plugins.register(plugins.ProviderPlugin)
 def providers():
     for network_name in NETWORKS:
-        yield "scroll", network_name, GethProvider
+        yield "scroll", network_name, Node
 
     yield "scroll", LOCAL_NETWORK_NAME, LocalProvider

--- a/setup.py
+++ b/setup.py
@@ -67,9 +67,9 @@ setup(
     url="https://github.com/theref/ape-scroll",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<1.0.0",
+        "eth-ape>=0.8.1,<0.9",
     ],
-    python_requires=">=3.8,<4",
+    python_requires=">=3.9,<4",
     extras_require=extras_require,
     py_modules=["ape_scroll"],
     license="Apache-2.0",
@@ -85,8 +85,9 @@ setup(
         "Operating System :: MacOS",
         "Operating System :: POSIX",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+        "Programming Language :: Python :: 3.12",
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     url="https://github.com/theref/ape-scroll",
     include_package_data=True,
     install_requires=[
-        "eth-ape>=0.6.0,<0.7",
+        "eth-ape>=0.6.0,<1.0.0",
     ],
     python_requires=">=3.8,<4",
     extras_require=extras_require,


### PR DESCRIPTION
~This PR loosens the eth-ape version restriction so we can use ape-scroll with the latest versions.~

This PR updates the plugin to be compatible with ape v0.8.x
Notable changes:
* replaced incompatible ape_geth with ape_node in `__init__.py`
* dropped support for python 3.8