### PR TITLE
fix: update CI script python versions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -19,7 +19,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: |
@@ -47,7 +47,7 @@ jobs:
         - name: Setup Python
           uses: actions/setup-python@v4
           with:
-              python-version: 3.8
+              python-version: 3.9
 
         - name: Install Dependencies
           run: |
@@ -63,7 +63,7 @@ jobs:
         strategy:
             matrix:
                 os: [ubuntu-latest, macos-latest]   # eventually add `windows-latest`
-                python-version: [3.8, 3.9, "3.10"]
+                python-version: ["3.9", "3.10", "3.11", "3.12"]
 
         steps:
         - uses: actions/checkout@v3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,4 +27,4 @@ repos:
         additional_dependencies: [types-setuptools, pydantic]
 
 default_language_version:
-    python: python3.8
+    python: python3.9


### PR DESCRIPTION
This PR updates the used python versions in `.pre-commit-config.yaml` and `.github/workflows/test.yaml`. I have tested the changes on my fork and all checks are green :green_heart: : https://github.com/Barabazs/ape-scroll/actions/runs/9600206224

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request updates the Python versions used in the CI workflow and pre-commit configuration. The GitHub Actions workflow now uses Python 3.9 and includes additional versions in the testing matrix. The pre-commit configuration has also been updated to use Python 3.9.

- **Build**:
    - Updated the default Python version in the pre-commit configuration to use Python 3.9 instead of 3.8.
- **CI**:
    - Updated the Python version in the GitHub Actions workflow configuration to use Python 3.9 instead of 3.8.
    - Expanded the matrix of Python versions in the GitHub Actions workflow to include Python 3.9, 3.10, 3.11, and 3.12.

<!-- Generated by sourcery-ai[bot]: end summary -->